### PR TITLE
Fix distance calculation

### DIFF
--- a/src/game/game.tsx
+++ b/src/game/game.tsx
@@ -38,7 +38,7 @@ export function calculateScore(
     // 20,0000 meters = 0 points
     // normalize to be 5,000 max score
     let curScore = Math.round(
-      (5000 / 400000000) * Math.max((20000 - distance) ** 2, 0)
+      (5000 / 400000000) * (Math.max(20000 - distance, 0) ** 2)
     );
 
     if (curScore >= score) {


### PR DESCRIPTION
There seems to be a typo in the distance -> score formula, resulting in extremely large scores if you place your marker anywhere outside of NYC.