### PR TITLE
Remove the Lefferts S shuttle

### DIFF
--- a/src/operators/mta/data.tsx
+++ b/src/operators/mta/data.tsx
@@ -423,8 +423,9 @@ export const stations: MtaStation[] = [
       lines[MtaLineName.FIVE],
       lines[MtaLineName.TWO],
       lines[MtaLineName.THREE],
+      lines[MtaLineName.S]
     ],
-    name: "Franklin Ave",
+    name: "Franklin Ave/Botanic Garden",
     coordinates: [[-73.9580997367769, 40.67076515344894]],
   },
   {
@@ -1703,11 +1704,6 @@ export const stations: MtaStation[] = [
     lines: [lines[MtaLineName.TWO]],
     name: "Wakefield - 241st St",
     coordinates: [[-73.8506199987954, 40.903125000541245]],
-  },
-  {
-    lines: [lines[MtaLineName.S]],
-    name: "Botanic Garden",
-    coordinates: [[-73.95924499945693, 40.670342666584396]],
   },
   {
     lines: [lines[MtaLineName.L]],

--- a/src/operators/mta/data.tsx
+++ b/src/operators/mta/data.tsx
@@ -631,7 +631,7 @@ export const stations: MtaStation[] = [
     coordinates: [[-73.95762400074634, 40.67477166685263]],
   },
   {
-    lines: [lines[MtaLineName.A], lines[MtaLineName.S]],
+    lines: [lines[MtaLineName.A]],
     name: "111th St",
     coordinates: [[-73.83216299845388, 40.68433100001238]],
   },
@@ -704,7 +704,7 @@ export const stations: MtaStation[] = [
     coordinates: [[-74.00536700180581, 40.728251000730204]],
   },
   {
-    lines: [lines[MtaLineName.A], lines[MtaLineName.S]],
+    lines: [lines[MtaLineName.A]],
     name: "104th St",
     coordinates: [[-73.83768300060997, 40.681711001091195]],
   },
@@ -743,7 +743,7 @@ export const stations: MtaStation[] = [
     coordinates: [[-73.9401635351909, 40.750635651014804]],
   },
   {
-    lines: [lines[MtaLineName.A], lines[MtaLineName.S]],
+    lines: [lines[MtaLineName.A]],
     name: "Rockaway Blvd",
     coordinates: [[-73.8438529979573, 40.680428999588415]],
   },
@@ -1247,7 +1247,7 @@ export const stations: MtaStation[] = [
     coordinates: [[-73.86161820097203, 40.729763972422425]],
   },
   {
-    lines: [lines[MtaLineName.A], lines[MtaLineName.S]],
+    lines: [lines[MtaLineName.A]],
     name: "Grant Ave",
     coordinates: [[-73.86504999877702, 40.67704400054478]],
   },
@@ -1267,7 +1267,7 @@ export const stations: MtaStation[] = [
     coordinates: [[-74.00290599855235, 40.73342200104225]],
   },
   {
-    lines: [lines[MtaLineName.A], lines[MtaLineName.S]],
+    lines: [lines[MtaLineName.A]],
     name: "Ozone Park - Lefferts Blvd",
     coordinates: [[-73.82579799906613, 40.68595099878361]],
   },
@@ -2645,12 +2645,12 @@ export const stations: MtaStation[] = [
     coordinates: [[-73.94747800152219, 40.79060000008452]],
   },
   {
-    lines: [lines[MtaLineName.A], lines[MtaLineName.C], lines[MtaLineName.S]],
+    lines: [lines[MtaLineName.A], lines[MtaLineName.C]],
     name: "Euclid Ave",
     coordinates: [[-73.87210600099675, 40.675376998239365]],
   },
   {
-    lines: [lines[MtaLineName.A], lines[MtaLineName.S]],
+    lines: [lines[MtaLineName.A]],
     name: "88th St",
     coordinates: [[-73.85147000026086, 40.67984300135503]],
   },
@@ -2679,7 +2679,7 @@ export const stations: MtaStation[] = [
     coordinates: [[-74.00688600277107, 40.719318001302135]],
   },
   {
-    lines: [lines[MtaLineName.A], lines[MtaLineName.S]],
+    lines: [lines[MtaLineName.A]],
     name: "80th St",
     coordinates: [[-73.85899200206335, 40.67937100115432]],
   },


### PR DESCRIPTION
[The late night shuttles](https://en.wikipedia.org/wiki/S_(New_York_City_Subway_service)#Late-night_shuttles) are miscoded. This shows up most significantly as the Lefferts Boulevard Shuttle being miscoded as a Grey-S in-game. Rather than adding the Blue-S (which is not used on official maps), this should be removed from the game to match.

Example: [Euclid Ave](https://en.wikipedia.org/wiki/Euclid_Avenue_station_(IND_Fulton_Street_Line)
) is marked in game as having A,C,S stops, but it only has A,C stops on the MTA map. Note that while Euclid has a late night *blue* S, this is not in the map, and certainly isn't a *grey* S.

![image](https://github.com/BenMusch/nycguessr/assets/1565833/5d17478c-359f-4d67-975f-0b5c844c3520)

Report credit goes to my four year old Amitav (a daily active user), who would like to add:
THERE IS NO S AT EUCLID AV, THERE IS ONLY AN A,C AT EUCLID AV.


While I was poking around in the data, I also happened to notice that Botanic Garden's is marked as a separate S station, so I merged it with the Franklin Ave 2/3/4/5 station.

I was unable to verify this fix works due to not finding a way to set the mapbox token #7, so submitting as-is for now.